### PR TITLE
Typo fixes on credits page

### DIFF
--- a/credits.php
+++ b/credits.php
@@ -434,7 +434,7 @@ following sources of highway information.</p>
 	<li><a href="http://www.cahighways.org/">California Highways</a>. Hobbyist website by Daniel Faigin.</li>
 
 	    </ul>
-	  </li> -->
+	  </li>
 	  <li>Colorado, USA
 	    <ul>
 <li><a href="http://corcohighways.org/">Corco Highways</a>. Hobbist site covering state highways.</li>
@@ -586,7 +586,7 @@ following sources of highway information.</p>
 <li><a href="http://dot.state.nm.us/content/dam/nmdot/Data_Management/POSTED%20ROUTE-NM_Routes.pdf">NMDOT Posted Routes for New Mexico Routes</a>. Official New Mexico Department of Transportation posted route legal descriptions.</li>
 <li><a href="http://dot.state.nm.us/content/dam/nmdot/Data_Management/NM_AADT_Listing.pdf">NMDOT AADT Listing</a>. Official New Mexico Department of Transportation TIMS road segments by posted route/point with AADT info.</li>
 <li><a href="http://www.steve-riner.com/nmhighways/NMHome.htm">The Unofficial New Mexico Highways Page</a>. Hobbyist site by Steve Riner, describing current and historical New Mexico state routes.</li>
-
+</ul>
 	  </li> 
 	  <li>New York, USA
 	    <ul>


### PR DESCRIPTION
My last update left California entries blank (commented out?), and threw off formatting of all entries after New Mexico. Hope this fixes both issues.