### PR TITLE
Routes Traveled ranking bugfix

### DIFF
--- a/user/region.php
+++ b/user/region.php
@@ -230,7 +230,6 @@ SQL;
 
             // Second, fetch routes clinched/driven
             $totalActiveRoutes = tm_count_rows("routes", "LEFT JOIN systems on routes.systemName = systems.systemName WHERE region = '$region' AND systems.level = 'active'");
-
             $totalActivePreviewRoutes = tm_count_rows("routes", "LEFT JOIN systems on routes.systemName = systems.systemName WHERE region = '$region' AND ".$activeClause." ");
 
             $sql_command = <<<SQL
@@ -239,7 +238,9 @@ SQL;
               COUNT(cr.route) AS driven,
               SUM(cr.clinched) AS clinched,
               ROUND(COUNT(cr.route) / $totalActiveRoutes * 100, 2) as drivenPct,
-              ROUND(sum(cr.clinched) / $totalActiveRoutes * 100, 2) as clinchedPct
+              ROUND(sum(cr.clinched) / $totalActiveRoutes * 100, 2) as clinchedPct,
+              RANK() OVER (ORDER BY COUNT(cr.route) DESC) drivenRank,
+              RANK() OVER (ORDER BY SUM(cr.clinched) DESC) clinchedRank
             FROM routes AS r
               LEFT JOIN clinchedRoutes AS cr
                 ON cr.route = r.root
@@ -247,20 +248,17 @@ SQL;
                 ON r.systemName = systems.systemName
             WHERE (r.region = '$region' AND 
                 systems.level = 'active')
-            GROUP BY traveler
-            ORDER BY clinchedPct DESC;
+            GROUP BY traveler;
 SQL;
 
             $activeDrivenRes = tmdb_query($sql_command);
-            $row = tm_fetch_user_row_with_rank($activeDrivenRes, 'clinchedPct');
+            $row = tm_fetch_user_row_with_rank($activeDrivenRes, 'clinchedPct'); //FIXME? We no longer need the rank, just the user row.
 	    $drivenActiveRoutes = $row['driven'];
 	    $drivenActiveRoutesPct = $row['drivenPct'];
 	    $clinchedActiveRoutes = $row['clinched'];
 	    $clinchedActiveRoutesPct = $row['clinchedPct'];
-	    $clinchedActiveRoutesRank = $row['rank'];
-	    $activeDrivenRes->data_seek(0);
-            $row = tm_fetch_user_row_with_rank($activeDrivenRes, 'drivenPct');
-	    $drivenActiveRoutesRank = $row['rank'];
+	    $clinchedActiveRoutesRank = $row['clinchedRank'];
+	    $drivenActiveRoutesRank = $row['drivenRank'];
 
 	    // add to the table of travelers by region stats
 	    $activeDrivenRes->data_seek(0);
@@ -275,7 +273,9 @@ SQL;
               COUNT(cr.route) AS driven,
               SUM(cr.clinched) AS clinched,
               ROUND(COUNT(cr.route) / $totalActivePreviewRoutes * 100, 2) as drivenPct,
-              ROUND(sum(cr.clinched) / $totalActivePreviewRoutes * 100, 2) as clinchedPct
+              ROUND(sum(cr.clinched) / $totalActivePreviewRoutes * 100, 2) as clinchedPct,
+              RANK() OVER (ORDER BY COUNT(cr.route) DESC) drivenRank,
+              RANK() OVER (ORDER BY SUM(cr.clinched) DESC) clinchedRank
             FROM routes AS r
               LEFT JOIN clinchedRoutes AS cr
                 ON cr.route = r.root
@@ -283,20 +283,17 @@ SQL;
                 ON r.systemName = systems.systemName
             WHERE (r.region = '$region' AND 
                 (systems.level='preview' OR systems.level='active'))
-            GROUP BY traveler
-            ORDER BY clinchedPct DESC;
+            GROUP BY traveler;
 SQL;
 
             $activePreviewDrivenRes = tmdb_query($sql_command);
-            $row = tm_fetch_user_row_with_rank($activePreviewDrivenRes, 'clinchedPct');
+            $row = tm_fetch_user_row_with_rank($activePreviewDrivenRes, 'clinchedPct'); //FIXME? We no longer need the rank, just the user row.
 	    $drivenActivePreviewRoutes = $row['driven'];
 	    $drivenActivePreviewRoutesPct = $row['drivenPct'];
 	    $clinchedActivePreviewRoutes = $row['clinched'];
 	    $clinchedActivePreviewRoutesPct = $row['clinchedPct'];
-	    $clinchedActivePreviewRoutesRank = $row['rank'];
-	    $activePreviewDrivenRes->data_seek(0);
-            $row = tm_fetch_user_row_with_rank($activePreviewDrivenRes, 'drivenPct');
-	    $drivenActivePreviewRoutesRank = $row['rank'];
+	    $clinchedActivePreviewRoutesRank = $row['clinchedRank'];
+	    $drivenActivePreviewRoutesRank = $row['drivenRank'];
 
 	    // add to the table of travelers by region stats
 	    $activePreviewDrivenRes->data_seek(0);
@@ -308,7 +305,7 @@ SQL;
 
 
             echo "<tr onClick=\"window.open('/shields/clinched.php?u={$tmuser}')\">";
-	    echo "<td>Routes Driven</td>";
+	    echo "<td>Routes Traveled</td>";
 	    echo "<td>".$drivenActiveRoutes." of " . $totalActiveRoutes . " (" . $drivenActiveRoutesPct . "%) Rank: ".$drivenActiveRoutesRank."</td>";
 	    echo "<td>".$drivenActivePreviewRoutes." of " . $totalActivePreviewRoutes . " (" . $drivenActivePreviewRoutesPct . "%) Rank: ".$drivenActivePreviewRoutesRank."</td>";
 	    echo "</tr>";

--- a/user/region.php
+++ b/user/region.php
@@ -252,7 +252,8 @@ SQL;
 SQL;
 
             $activeDrivenRes = tmdb_query($sql_command);
-            $row = tm_fetch_user_row_with_rank($activeDrivenRes, 'clinchedPct'); //FIXME? We no longer need the rank, just the user row.
+	    $row = $activeDrivenRes->fetch_assoc();
+	    while($row['traveler'] != $tmuser && $row = $activeDrivenRes->fetch_assoc());
 	    $drivenActiveRoutes = $row['driven'];
 	    $drivenActiveRoutesPct = $row['drivenPct'];
 	    $clinchedActiveRoutes = $row['clinched'];
@@ -287,7 +288,8 @@ SQL;
 SQL;
 
             $activePreviewDrivenRes = tmdb_query($sql_command);
-            $row = tm_fetch_user_row_with_rank($activePreviewDrivenRes, 'clinchedPct'); //FIXME? We no longer need the rank, just the user row.
+	    $row = $activePreviewDrivenRes->fetch_assoc();
+	    while($row['traveler'] != $tmuser && $row = $activePreviewDrivenRes->fetch_assoc());
 	    $drivenActivePreviewRoutes = $row['driven'];
 	    $drivenActivePreviewRoutesPct = $row['drivenPct'];
 	    $clinchedActivePreviewRoutes = $row['clinched'];

--- a/user/system.php
+++ b/user/system.php
@@ -230,7 +230,8 @@ SQL;
 SQL;
             }
             $res = tmdb_query($sql_command);
-            $row = tm_fetch_user_row_with_rank($res, 'clinched'); //FIXME? We no longer need the rank, just the user row.
+	    $row = $res->fetch_assoc();
+	    while($row['traveler'] != $tmuser && $row = $res->fetch_assoc());
             $res->free();
             echo "<tr onClick=\"" . $link . "\"><td>Routes Traveled</td><td>" . $row['driven']   . " of " . $totalRoutes . " (" . round($row['driven']   / $totalRoutes * 100, 2) . "%) Rank: {$row['drivenRank']}</td></tr>\n";
 	    echo "<tr onClick=\"" . $link . "\"><td>Routes Clinched</td><td>" . $row['clinched'] . " of " . $totalRoutes . " (" . round($row['clinched'] / $totalRoutes * 100, 2) . "%) Rank: {$row['clinchedRank']}</td></tr>\n";


### PR DESCRIPTION
Closes #278.

https://github.com/TravelMapping/Web/blob/f8c6c793de2c72e29a702d369c2c8028c3314dd0/user/region.php#L255-L256
https://github.com/TravelMapping/Web/blob/f8c6c793de2c72e29a702d369c2c8028c3314dd0/user/region.php#L291-L292
https://github.com/TravelMapping/Web/blob/f8c6c793de2c72e29a702d369c2c8028c3314dd0/user/system.php#L233-L234

These three bits still bother me a little. I'd like a more elegant way to just fetch the one row we need  with a single function. If such exists, I haven't learned what it is yet; it seems I have to use a while loop. (?)

Also a little nervous about ending the line with a `;` rather than a ` {}`. I'm brand new to PHP, don't know how standard syntax that is, or whether FreeBSD will be OK with it.
We may want to try this out on tmtest before the production site?