### PR TITLE
coords/Acme/HA links

### DIFF
--- a/wptedit/index.php
+++ b/wptedit/index.php
@@ -143,12 +143,6 @@ var map;
 //var infowindow;
 var trace;
 
-function OSMUrl(lat, lon) {return "http://www.openstreetmap.org/?lat=" + lat.toFixed(6) + "&amp;lon=" + lon.toFixed(6);};
-function YahooUrl(lat, lon) {return "http://maps.yahoo.com/#mvt=m&amp;lat=" + lat.toFixed(6) + "&amp;lon=" + lon.toFixed(6) + "&amp;zoom=16";};
-function GoogleUrl(lat, lon) {return "http://maps.google.com/maps?ll=" + lat.toFixed(6) + "," + lon.toFixed(6) + "&amp;z=15";};
-function BingUrl(lat, lon) {return "http://www.bing.com/maps/?v=2&amp;cp=" + lat.toFixed(6) + "~" + lon.toFixed(6) + "&amp;lvl=15";};
-function GMSVUrl(lat, lon) {return "http://maps.google.com/?ll=" + lat.toFixed(6) + "," + lon.toFixed(6) + "&amp;cbp=12,0,,0,5&amp;cbll=" + lat.toFixed(6) + "," + lon.toFixed(6) + "&amp;layer=c";};
-
 function recenter(ev) {
 
   console.log("dblclick event");

--- a/wptedit/wptfunctions.js
+++ b/wptedit/wptfunctions.js
@@ -1443,15 +1443,22 @@ function IsVisible(label)
 
 
 function OSMUrl(lat, lon) {return "http://www.openstreetmap.org/?lat=" + lat.toFixed(6) + "&amp;lon=" + lon.toFixed(6);};
-function YahooUrl(lat, lon) {return "http://maps.yahoo.com/#mvt=m&amp;lat=" + lat.toFixed(6) + "&amp;lon=" + lon.toFixed(6) + "&amp;zoom=16";};
 function GoogleUrl(lat, lon) {return "http://maps.google.com/maps?ll=" + lat.toFixed(6) + "," + lon.toFixed(6) + "&amp;z=15";};
 function BingUrl(lat, lon) {return "http://www.bing.com/maps/?v=2&amp;cp=" + lat.toFixed(6) + "~" + lon.toFixed(6) + "&amp;lvl=15";};
 function GMSVUrl(lat, lon) {return "http://maps.google.com/?ll=" + lat.toFixed(6) + "," + lon.toFixed(6) + "&amp;cbp=12,0,,0,5&amp;cbll=" + lat.toFixed(6) + "," + lon.toFixed(6) + "&amp;layer=c";};
+function AcmeUrl(lat, lon) {return "http://mapper.acme.com/?ll=" + lat.toFixed(6) + "," + lon.toFixed(6) + "&amp;z=15";};
+function HAUrl(lat, lon) {return "https://historicaerials.com/location/" + lat.toFixed(6) + "/" + lon.toFixed(6) + "/map/15";};
 
 function UpdateCoords() 
 {     
   var center = map.getCenter();    
-    document.getElementById("coordbar").innerHTML = '<a onclick="javascript:AddWaypoint();" class="button">Add waypoint</a> ' + OSMUrl(center.lat, center.lng) + "<br>Open location in <a href='" + GMSVUrl(center.lat, center.lng) + "' target='sv' class='button'>Street View</a> <a href='" + OSMUrl(center.lat, center.lng) + "&amp;zoom=15' target='o' class='button'>OSM</a> <a href='" + GoogleUrl(center.lat, center.lng) + "' target='g' class='button'>Google</a> <a href='" + YahooUrl(center.lat, center.lng) + "' target='y' class='button'>Yahoo</a> <a href='" + BingUrl(center.lat, center.lng) + "' target='b' class='button'>Bing</a>";    
+    document.getElementById("coordbar").innerHTML = '<a onclick="javascript:AddWaypoint();" class="button">Add waypoint</a> ' + OSMUrl(center.lat, center.lng) + "<br>Open location in" +
+      " <a href='" + GMSVUrl(center.lat, center.lng) + "' target='sv' class='button'>Street View</a>" +
+      " <a href='" + OSMUrl(center.lat, center.lng) + "&amp;zoom=15' target='o' class='button'>OSM</a>" +
+      " <a href='" + GoogleUrl(center.lat, center.lng) + "' target='g' class='button'>Google</a>" +
+      " <a href='" + BingUrl(center.lat, center.lng) + "' target='b' class='button'>Bing</a>" +
+      " <a href='" + AcmeUrl(center.lat, center.lng) + "' target='a' class='button'>Acme</a>" +
+      " <a href='" + HAUrl(center.lat, center.lng) + "' target='h' class='button'>HA</a>";
 }
 
 function ChangeLineThickness(t)

--- a/wptedit/wptfunctions.js
+++ b/wptedit/wptfunctions.js
@@ -928,7 +928,9 @@ function MarkerInfo(i, n, wpt)
 
   }
   info += '<a onclick="AddAltlabelWaypoint(' + i + ')" class="button">Add Alt. Label</\a><br>';
-  info += '<br><b>Waypoint ' + (i+1) + ' of ' + n + '<\/b><br><b>Coords.:<\/b> ' + wpt.lat + '&deg;, ' + wpt.lon + '&deg;<\/p>';
+  info += '<br><b>Waypoint ' + (i+1) + ' of ' + n + '<\/b><br><b>';
+  info += '<a target="o" href="http://www.openstreetmap.org/?lat=' + wpt.lat + '&lon=' + wpt.lon + '">';
+  info += 'Coords.:<\/a><\/b> ' + wpt.lat + '&deg;, ' + wpt.lon + '&deg;<\/p>';
 
   if(i == thawindex)
     info += '<p style="color:#990000;font-weight:bold;">This waypoint can be repositioned.</p>';


### PR DESCRIPTION
* Closes #539.
Done not HB-style but rather HDX-style: the link is only the string **Coords.:**, and not the coordinate numbers themselves. I sometimes find it useful to copy that string, and this makes it slightly more convenient to do that.
* Closes #356.
While in there, I replaced the vestigial Yahoo button with buttons for Acme Mapper and/or Historic Aerials.