### PR TITLE
Shields: frad/fram/irlr Refinement

### DIFF
--- a/shields/template_frad_wide3.svg
+++ b/shields/template_frad_wide3.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="200" height="100" rx="20" fill="#F9BA11" />
-	<text x="100" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="200" height="100" rx="10" fill="#F9BA11" />
+	<text x="100" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_frad_wide4.svg
+++ b/shields/template_frad_wide4.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" viewBox="0 0 250 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="250" height="100" rx="20" fill="#F9BA11" />
-	<text x="125" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+<svg version="1.1" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+	<rect width="200" height="100" rx="10" fill="#F9BA11" />
+	<text x="100" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_frad_wide4.svg
+++ b/shields/template_frad_wide4.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="200" height="100" rx="10" fill="#F9BA11" />
-	<text x="100" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
+<svg version="1.1" viewBox="0 0 250 100" xmlns="http://www.w3.org/2000/svg">
+	<rect width="250" height="100" rx="10" fill="#F9BA11" />
+	<text x="125" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_frad_wide5.svg
+++ b/shields/template_frad_wide5.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="300" height="100" rx="20" fill="#F9BA11" />
-	<text x="150" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="300" height="100" rx="10" fill="#F9BA11" />
+	<text x="150" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_frad_wide6.svg
+++ b/shields/template_frad_wide6.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 350 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="350" height="100" rx="20" fill="#F9BA11" />
-	<text x="175" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="350" height="100" rx="10" fill="#F9BA11" />
+	<text x="175" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_frad_wide7.svg
+++ b/shields/template_frad_wide7.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="400" height="100" rx="20" fill="#F9BA11" />
-	<text x="200" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="400" height="100" rx="10" fill="#F9BA11" />
+	<text x="200" y="80" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_fram_wide3.svg
+++ b/shields/template_fram_wide3.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="200" height="100" rx="20" fill="#2A7FFF" />
-	<text x="100" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="200" height="100" rx="10" fill="#2A7FFF" />
+	<text x="100" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_fram_wide4.svg
+++ b/shields/template_fram_wide4.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 250 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="250" height="100" rx="20" fill="#2A7FFF" />
-	<text x="125" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="250" height="100" rx="10" fill="#2A7FFF" />
+	<text x="125" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_fram_wide5.svg
+++ b/shields/template_fram_wide5.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 300 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="300" height="100" rx="20" fill="#2A7FFF" />
-	<text x="150" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="300" height="100" rx="10" fill="#2A7FFF" />
+	<text x="150" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_fram_wide6.svg
+++ b/shields/template_fram_wide6.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 350 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="350" height="100" rx="20" fill="#2A7FFF" />
-	<text x="175" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="350" height="100" rx="10" fill="#2A7FFF" />
+	<text x="175" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_fram_wide7.svg
+++ b/shields/template_fram_wide7.svg
@@ -1,4 +1,4 @@
 <svg version="1.1" viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg">
-	<rect width="400" height="100" rx="20" fill="#2A7FFF" />
-	<text x="200" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve">***NUMBER***</text>
+	<rect width="400" height="100" rx="10" fill="#2A7FFF" />
+	<text x="200" y="80" fill="#FFF" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle" xml:space="preserve"><tspan>***NUMBER***</tspan><tspan font-size="45" dy="-30">***SUFFIX***</tspan></text>
 </svg>

--- a/shields/template_irlr.svg
+++ b/shields/template_irlr.svg
@@ -1,5 +1,5 @@
-<svg version="1.1" viewBox="0 0 250 110" xmlns="http://www.w3.org/2000/svg">
-	<rect width="250" height="110" rx="10" fill="#000" />
-	<rect x="5" y="5" width="240" height="100" rx="25" fill="#fff" />
-	<text x="125" y="85" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle">***NUMBER***</text>
+<svg version="1.1" viewBox="0 0 260 120" xmlns="http://www.w3.org/2000/svg">
+	<rect width="260" height="120" rx="25" fill="#000" />
+	<rect x="10" y="10" width="240" height="100" rx="35" fill="#fff" />
+	<text x="130" y="90" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle">***NUMBER***</text>
 </svg>

--- a/shields/template_irlr.svg
+++ b/shields/template_irlr.svg
@@ -1,5 +1,5 @@
 <svg version="1.1" viewBox="0 0 260 120" xmlns="http://www.w3.org/2000/svg">
-	<rect width="260" height="120" rx="25" fill="#000" />
-	<rect x="10" y="10" width="240" height="100" rx="35" fill="#fff" />
+	<rect width="260" height="120" rx="20" fill="#000" />
+	<rect x="10" y="10" width="240" height="100" rx="30" fill="#fff" />
 	<text x="130" y="90" fill="#000" font-family="&apos;Roadgeek 2005 Transport Heavy&apos;" font-size="90" text-align="center" text-anchor="middle">***NUMBER***</text>
 </svg>


### PR DESCRIPTION
- Refined suffixes for frad/fram
- frad now includes fracord
- Reduced border radius or frad/fram from 20 to 10 (equal to fraa and fran)
- Adjusted irlr
- imnb and jeyc now use the Great Britain B Roads template
- Adjusted Shieldgen to use a simpler substring replace function for some prefix replacements.