### PR TITLE
COMBINE_CON_ROUTES (Web)

### DIFF
--- a/devel/datacheck.php
+++ b/devel/datacheck.php
@@ -50,13 +50,20 @@
         echo "<tr><td><a href=\"../hb/showroute.php?r=".$row['route'];
 	// successful lookup of waypoint label links to panned & zoomed map
 	if ($row2 != NULL) {
-	  echo "&lat=".$row2['latitude']."&lon=".$row2['longitude']."&zoom=17";
+	  echo "&lat=".$row2['latitude']."&lon=".$row2['longitude']."&zoom=";
+	  if (strcmp($row['code'],"COMBINE_CON_ROUTES") == 0) {
+	    echo "10";
+	  }
+	  else {
+	    echo "17";
+	  }
 	}
 	// the following errors link to a ConnectedRoute
 	if ((strcmp($row['code'],"ABBREV_AS_CON_BANNER") == 0) ||
-	(strcmp($row['code'],"CON_ROUTE_MISMATCH") == 0) ||
-	(strcmp($row['code'],"CON_BANNER_MISMATCH") == 0) ||
-	(strcmp($row['code'],"DISCONNECTED_ROUTE") == 0)) {
+	  (strcmp($row['code'],"COMBINE_CON_ROUTES") == 0) ||
+	  (strcmp($row['code'],"CON_ROUTE_MISMATCH") == 0) ||
+	  (strcmp($row['code'],"CON_BANNER_MISMATCH") == 0) ||
+	  (strcmp($row['code'],"DISCONNECTED_ROUTE") == 0)) {
 	  echo "&cr";
 	}
 	echo "\">".$row['route']."</a></td><td>";
@@ -121,6 +128,13 @@
 	    (strcmp($row['code'],"ABBREV_AS_CHOP_BANNER") == 0)) {
             echo "<a href=\"https://github.com/TravelMapping/HighwayData/blob/master/hwy_data/_systems/".$row['value']."\">".$row['value']."</a>";
 	  }
+	  // COMBINE_CON_ROUTES links to 2nd ConnectedRoute
+	  elseif (strcmp($row['code'],"COMBINE_CON_ROUTES") == 0) {
+	    $r_at_l = explode('@', $row['value']);
+	    $sql_command = "select latitude, longitude from waypoints where pointName = '".$r_at_l[1]."' and root = '".$row['route']."';";
+	    $row2 = tmdb_query($sql_command)->fetch_assoc();
+            echo "<a href=\"../hb/showroute.php?cr&r=".$r_at_l[0]."&lat=".$row2['latitude']."&lon=".$row2['longitude']."&zoom=10\">".$row['value']."</a>";
+	  }
 	  else {
             echo $row['value'];
 	  }
@@ -140,6 +154,7 @@
 	  strcmp($row['code'],"VISIBLE_HIDDEN_COLOC") &&
 	  strcmp($row['code'],"HIDDEN_JUNCTION") &&
 	  strcmp($row['code'],"LACKS_GENERIC") &&
+	  strcmp($row['code'],"COMBINE_CON_ROUTES") &&
 	  strcmp($row['code'],"BUS_WITH_I") &&
 	  strcmp($row['code'],"OUT_OF_BOUNDS")) {
 

--- a/devel/manual/syserr.php
+++ b/devel/manual/syserr.php
@@ -125,6 +125,13 @@ Data errors</p>
     <td><green>YES</green></td>
   </tr>
   <tr valign="top">
+    <td><a name="COMBINE_CON_ROUTES"></a><a style="text-decoration:none" href="#COMBINE_CON_ROUTES">&#x1f517</a></td>
+    <td>COMBINE_CON_ROUTES</td>
+    <td>Two separate ConnectedRoutes could potentially be combined into one.</td>
+    <td><red>NO</red></td>
+    <td><green>YES</green></td>
+  </tr>
+  <tr valign="top">
     <td><a name="CON_BANNER_MISMATCH"></a><a style="text-decoration:none" href="#CON_BANNER_MISMATCH">&#x1f517</a></td>
     <td>CON_BANNER_MISMATCH</td>
     <td>The route's <a href="syshwylist.php#cbanner">Banner</a> field in its <a href="syshwylist.php#chopped">chopped routes .csv file</a> mismatches the <a href="syshwylist.php#conncbanner">Banner</a> field in its <a href="syshwylist.php#connected">connected routes .csv file</a>.</td>


### PR DESCRIPTION
See https://github.com/TravelMapping/DataProcessing/pull/662.

This isn't what I originally had in mind when I posted [on the forum](https://forum.travelmapping.net/index.php?topic=3724.msg36065#msg36065), but may be another item for tmtest,
as lab2 is down *(possibly for good?)*, so I can't test this out locally until I get another server up & running.

If we don't merge this in right away and merge TravelMapping/DataProcessing#662 in without it,
it's not the end of the world:
* Bells & whistles like the 2nd HB link in the `Info` column unavailable.
* FP codes would not be shown, instead falsely claiming *This is always a true error and cannot be marked false positive.*
  Not a big deal in the immediate term -- since [HighwayData#7812](https://github.com/TravelMapping/HighwayData/pull/7812), there are only 2 errors left.
  These are pretty uncommon and I doubt any genuine FPs will make their way in before we get this sorted.
* Link to syserr.php would be broken. *Unless...*

Alternately...
1. I've split this out into 2 commits in case you want to merge just the syserr.php commit for the time being.
2. Or, you could even merge the whole thing and `git checkout d61b93b` if it didn't work. Whatever's clever.
3. I'd prefer option 1 over option 2 though.