### PR TITLE
Fix for #967

### DIFF
--- a/lib/mapviewfuncs.js
+++ b/lib/mapviewfuncs.js
@@ -116,8 +116,8 @@ function updateConnectionColors() {
 	    (highlightScheme == "none")) {
 	    highlight = 0;
 	}
-	if ((highlightScheme == "hidetraveled" && value.TMclinched == 0) ||
-	    (highlightScheme == "hideuntraveled" && value.TMclinched == 1) ||
+	if ((highlightScheme == "hidetraveled" && value.TMclinched == 1) ||
+	    (highlightScheme == "hideuntraveled" && value.TMclinched == 0) ||
 	    (highlightScheme == "hideall")) {
 	    highlight = -0.545454;
 	}


### PR DESCRIPTION
I accidentally had "Display Traveled Only" showing only untraveled segments and vice versa. This should swap them to work correctly for #771.