### PR TITLE
Added a double dropdown/collapsible for Region Selector in Highway Browser

### DIFF
--- a/hb/index.php
+++ b/hb/index.php
@@ -43,6 +43,27 @@
             font-size: 14px;
 	}
 
+    /* Collapsible region select */
+    .crs-wrapper { display: inline-block; position: relative; vertical-align: middle; }
+    .crs-display {
+        border: 1px solid #aaa; padding: 1px 6px; cursor: pointer; background: white;
+        min-width: 180px; display: flex; justify-content: space-between; align-items: center;
+        user-select: none; font-size: 13px; height: 22px; box-sizing: border-box;
+    }
+    .crs-arrow { margin-left: 6px; font-size: 10px; }
+    .crs-dropdown {
+        position: absolute; top: 100%; left: 0; min-width: 100%; max-height: 300px;
+        overflow-y: auto; border: 1px solid #aaa; background: white; z-index: 1000; font-size: 13px;
+    }
+    .crs-option { padding: 2px 8px; cursor: pointer; white-space: nowrap; }
+    .crs-option:hover, .crs-option.crs-selected { background-color: #0078d7; color: white; }
+    .crs-group-label {
+        padding: 2px 8px; font-weight: bold; cursor: pointer;
+        background-color: #f0f0f0; white-space: nowrap; user-select: none;
+    }
+    .crs-group-label:hover { background-color: #ddd; }
+    .crs-group-item { padding-left: 20px; }
+    .crs-group-arrow { display: inline-block; width: 12px; font-size: 10px; }
     </style>
     <?php
     // check for region and/or system parameters
@@ -157,6 +178,94 @@ JS;
             ?>
         }
     );
+</script>
+<script type="text/javascript">
+function buildCollapsibleRegionSelect() {
+    var $select = $("#region");
+    if (!$select.length) return;
+
+    var selectedVal = $select.val() || "null";
+    var selectedText = "[None Selected]";
+    if (selectedVal !== "null") {
+        $select.find("option[value='" + selectedVal + "']").each(function() {
+            selectedText = $(this).text();
+        });
+    }
+
+    var $wrapper  = $('<div class="crs-wrapper"></div>');
+    var $display  = $('<div class="crs-display"><span class="crs-text"></span><span class="crs-arrow">&#9660;</span></div>');
+    $display.find(".crs-text").text(selectedText);
+    var $dropdown = $('<div class="crs-dropdown" style="display:none;"></div>');
+
+    var $none = $('<div class="crs-option" data-value="null">[None Selected]</div>');
+    if (selectedVal === "null") $none.addClass("crs-selected");
+    $dropdown.append($none);
+
+    $select.children().each(function() {
+        if (this.tagName === "OPTGROUP") {
+            var $group = $('<div class="crs-group"></div>');
+            var $label = $('<div class="crs-group-label"><span class="crs-group-arrow">&#9654;</span> </div>');
+            $label.append(document.createTextNode($(this).attr("label")));
+            var $items = $('<div class="crs-group-items" style="display:none;"></div>');
+            var groupHasSelected = false;
+            $(this).children("option").each(function() {
+                var val = this.value;
+                var $item = $('<div class="crs-option crs-group-item"></div>').attr("data-value", val).text($(this).text());
+                if (val === selectedVal) { $item.addClass("crs-selected"); groupHasSelected = true; }
+                $items.append($item);
+            });
+            if (groupHasSelected) {
+                $items.show();
+                $label.find(".crs-group-arrow").html("&#9660;");
+                $label.data("expanded", true);
+            }
+            $group.append($label).append($items);
+            $dropdown.append($group);
+        } else if (this.tagName === "OPTION" && this.value !== "null") {
+            var val = this.value;
+            var $opt = $('<div class="crs-option"></div>').attr("data-value", val).text($(this).text());
+            if (val === selectedVal) $opt.addClass("crs-selected");
+            $dropdown.append($opt);
+        }
+    });
+
+    $wrapper.append($display).append($dropdown);
+    $select.hide().after($wrapper);
+
+    $display.on("click", function(e) {
+        e.stopPropagation();
+        $dropdown.toggle();
+        $display.find(".crs-arrow").html($dropdown.is(":visible") ? "&#9650;" : "&#9660;");
+    });
+
+    $dropdown.on("click", ".crs-group-label", function(e) {
+        e.stopPropagation();
+        var $lbl = $(this);
+        var $items = $lbl.next(".crs-group-items");
+        var expanded = !!$lbl.data("expanded");
+        $items.toggle(!expanded);
+        $lbl.data("expanded", !expanded);
+        $lbl.find(".crs-group-arrow").html(!expanded ? "&#9660;" : "&#9654;");
+    });
+
+    $dropdown.on("click", ".crs-option", function(e) {
+        e.stopPropagation();
+        var val = $(this).data("value");
+        $select.val(val);
+        $display.find(".crs-text").text($(this).text());
+        $dropdown.find(".crs-selected").removeClass("crs-selected");
+        $(this).addClass("crs-selected");
+        $dropdown.hide();
+        $display.find(".crs-arrow").html("&#9660;");
+    });
+
+    $(document).on("click.crs", function() {
+        $dropdown.hide();
+        $display.find(".crs-arrow").html("&#9660;");
+    });
+}
+
+$(document).ready(function() { buildCollapsibleRegionSelect(); });
 </script>
 
 <?php

--- a/hb/index.php
+++ b/hb/index.php
@@ -64,6 +64,7 @@
     .crs-group-label:hover { background-color: #ddd; }
     .crs-group-item { padding-left: 20px; }
     .crs-group-arrow { display: inline-block; width: 12px; font-size: 10px; }
+    .crs-option.crs-focused, .crs-group-label.crs-focused { outline: 2px solid #005fa3; outline-offset: -2px; }
     </style>
     <?php
     // check for region and/or system parameters
@@ -193,7 +194,7 @@ function buildCollapsibleRegionSelect() {
     }
 
     var $wrapper  = $('<div class="crs-wrapper"></div>');
-    var $display  = $('<div class="crs-display"><span class="crs-text"></span><span class="crs-arrow">&#9660;</span></div>');
+    var $display  = $('<div class="crs-display" tabindex="0"><span class="crs-text"></span><span class="crs-arrow">&#9660;</span></div>');
     $display.find(".crs-text").text(selectedText);
     var $dropdown = $('<div class="crs-dropdown" style="display:none;"></div>');
 
@@ -232,16 +233,117 @@ function buildCollapsibleRegionSelect() {
     $wrapper.append($display).append($dropdown);
     $select.hide().after($wrapper);
 
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    function openDropdown() {
+        $dropdown.show();
+        $display.find(".crs-arrow").html("&#9650;");
+        // focus the currently-selected option, or the first item
+        var $sel = $dropdown.find(".crs-selected:visible");
+        var toFocus = $sel.length ? $sel[0] : $dropdown.find(".crs-option:visible")[0];
+        setFocused(toFocus);
+        if (toFocus) toFocus.scrollIntoView({ block: "nearest" });
+    }
+
+    function closeDropdown() {
+        $dropdown.hide();
+        $display.find(".crs-arrow").html("&#9660;");
+        $dropdown.find(".crs-focused").removeClass("crs-focused");
+    }
+
+    function setFocused(el) {
+        $dropdown.find(".crs-focused").removeClass("crs-focused");
+        if (el) $(el).addClass("crs-focused");
+    }
+
+    function visibleNavigable() {
+        // group labels + options that are currently visible
+        return $dropdown.find(".crs-group-label:visible, .crs-option:visible").toArray();
+    }
+
+    function moveFocus(delta) {
+        var items = visibleNavigable();
+        if (!items.length) return;
+        var cur = $dropdown.find(".crs-focused")[0];
+        var idx = items.indexOf(cur);
+        idx = (idx + delta + items.length) % items.length;
+        setFocused(items[idx]);
+        items[idx].scrollIntoView({ block: "nearest" });
+    }
+
+    function activateFocused() {
+        var $f = $dropdown.find(".crs-focused");
+        if ($f.hasClass("crs-group-label")) {
+            $f.trigger("click");          // toggle group
+        } else if ($f.hasClass("crs-option")) {
+            selectOption($f);
+        }
+    }
+
+    function selectOption($opt) {
+        var val = $opt.data("value");
+        $select.val(val);
+        $display.find(".crs-text").text($opt.text());
+        $dropdown.find(".crs-selected").removeClass("crs-selected");
+        $opt.addClass("crs-selected");
+        closeDropdown();
+        $display.focus();
+    }
+
+    function expandGroupOf(el) {
+        var $group = $(el).closest(".crs-group");
+        if (!$group.length) return;
+        var $lbl   = $group.find(".crs-group-label");
+        var $items = $group.find(".crs-group-items");
+        if (!$items.is(":visible")) {
+            $items.show();
+            $lbl.data("expanded", true);
+            $lbl.find(".crs-group-arrow").html("&#9660;");
+        }
+    }
+
+    // ── type-ahead ───────────────────────────────────────────────────────────
+
+    var taBuffer = "", taTimer = null;
+
+    function typeahead(ch) {
+        taBuffer += ch.toLowerCase();
+        clearTimeout(taTimer);
+        taTimer = setTimeout(function() { taBuffer = ""; }, 800);
+
+        var $opts = $dropdown.find(".crs-option");   // all, including hidden
+        var cur   = $dropdown.find(".crs-focused")[0];
+        var all   = $opts.toArray();
+        var start = cur ? (all.indexOf(cur) + 1) : 0;
+
+        // search from current position, wrap around
+        for (var i = 0; i < all.length; i++) {
+            var el = all[(start + i) % all.length];
+            if ($(el).text().toLowerCase().indexOf(taBuffer) === 0) {
+                expandGroupOf(el);           // auto-expand group if needed
+                setFocused(el);
+                el.scrollIntoView({ block: "nearest" });
+                return;
+            }
+        }
+        // no match — reset buffer to just this character and retry once
+        if (taBuffer.length > 1) {
+            taBuffer = ch.toLowerCase();
+            typeahead("");    // retry (taBuffer already set, ch="" won't append)
+        }
+    }
+
+    // ── mouse events ─────────────────────────────────────────────────────────
+
     $display.on("click", function(e) {
         e.stopPropagation();
-        $dropdown.toggle();
-        $display.find(".crs-arrow").html($dropdown.is(":visible") ? "&#9650;" : "&#9660;");
+        $dropdown.is(":visible") ? closeDropdown() : openDropdown();
     });
 
     $dropdown.on("click", ".crs-group-label", function(e) {
         e.stopPropagation();
-        var $lbl = $(this);
-        var $items = $lbl.next(".crs-group-items");
+        var $lbl     = $(this);
+        var $items   = $lbl.next(".crs-group-items");
         var expanded = !!$lbl.data("expanded");
         $items.toggle(!expanded);
         $lbl.data("expanded", !expanded);
@@ -250,18 +352,41 @@ function buildCollapsibleRegionSelect() {
 
     $dropdown.on("click", ".crs-option", function(e) {
         e.stopPropagation();
-        var val = $(this).data("value");
-        $select.val(val);
-        $display.find(".crs-text").text($(this).text());
-        $dropdown.find(".crs-selected").removeClass("crs-selected");
-        $(this).addClass("crs-selected");
-        $dropdown.hide();
-        $display.find(".crs-arrow").html("&#9660;");
+        selectOption($(this));
     });
 
-    $(document).on("click.crs", function() {
-        $dropdown.hide();
-        $display.find(".crs-arrow").html("&#9660;");
+    $(document).on("click.crs", function() { closeDropdown(); });
+
+    // ── keyboard events ───────────────────────────────────────────────────────
+
+    $display.on("keydown", function(e) {
+        var open = $dropdown.is(":visible");
+        switch (e.key) {
+            case "ArrowDown":
+                e.preventDefault();
+                open ? moveFocus(1) : openDropdown();
+                break;
+            case "ArrowUp":
+                e.preventDefault();
+                open ? moveFocus(-1) : openDropdown();
+                break;
+            case "Enter":
+            case " ":
+                e.preventDefault();
+                open ? activateFocused() : openDropdown();
+                break;
+            case "Escape":
+                if (open) { e.preventDefault(); closeDropdown(); }
+                break;
+            case "Tab":
+                if (open) closeDropdown();
+                break;
+            default:
+                if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+                    if (!open) openDropdown();
+                    typeahead(e.key);
+                }
+        }
     });
 }
 

--- a/lib/tmphpuser.php
+++ b/lib/tmphpuser.php
@@ -36,7 +36,11 @@ if (array_key_exists("u", $_GET)) {
 	    ]);
     }
 } else if (isset($_COOKIE['lastuser'])) {
-    header("Location: ?u=" . $_COOKIE['lastuser'] . "&" . parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY)); /* Redirect browser */
+    $tmuri_path  = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    $tmuri_query = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+    $tmredirect  = "u=" . rawurlencode($_COOKIE['lastuser']);
+    if ($tmuri_query) $tmredirect .= "&" . $tmuri_query;
+    header("Location: " . $tmuri_path . "?" . $tmredirect);
     exit;
 }
 
@@ -78,8 +82,12 @@ if (array_key_exists("units", $_GET)) {
    }
 }
 else if (isset($_COOKIE['units'])) {
-   header("Location: ?units=" .$_COOKIE['units'] . "&" . parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY)); /* Redirect browser */
-   exit;
+    $tmuri_path  = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    $tmuri_query = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+    $tmredirect  = "units=" . rawurlencode($_COOKIE['units']);
+    if ($tmuri_query) $tmredirect .= "&" . $tmuri_query;
+    header("Location: " . $tmuri_path . "?" . $tmredirect);
+    exit;
 }
 
 ?>


### PR DESCRIPTION
## TLDR

Added a collapsible Region dropdown.

Region selection now supports expandable country groups while keeping the original hidden `<select>` for form submission.

## Changes

- Added CSS for the collapsible region select UI
- Added `buildCollapsibleRegionSelect()` in `index.php`
- Hid the native `<select id="region">` but kept it in the DOM
- Added a custom dropdown display next to the hidden select
- Added `[None Selected]` as a selectable option with value `"null"`
- Converted `<optgroup>` countries into collapsible headers
- Displayed grouped regions as indented clickable options
- Auto-expands a country group when one of its regions is already selected
- Updates the hidden native select when a custom option is clicked
- Closes the dropdown when clicking outside of it
- Updates arrows for dropdown/group expanded and collapsed states

## Structure

```text
v Region Dropdown
    [None Selected]
    Single-Region Country
    v Multi-Region Country 1 *
        Region 1
        Region 2
        Region 3
    > Multi-Region Country 2 *

\* Countries with multiple regions are displayed as collapsible groups

## Additional Info

Edited:
- `index.php`

Added:
- CSS for custom dropdown styling
- JavaScript widget for collapsible region selection

## Notes

- `array_diff(..., array("null"))` strips the `"null"` value server-side so `"None Selected"` works correctly
- The hidden native `<select>` remains the source of truth for form submission and compatibility